### PR TITLE
Remove unused set of cfg.cookies.

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -375,7 +375,7 @@ module.exports = exports = function dbScope (cfg) {
     // ?drilldown=["author","Dickens"]&drilldown=["publisher","Penguin"]
     req.qsStringifyOptions = { arrayFormat: 'repeat' }
 
-    cfg.cookies = cookieJar.getCookiesSync(cfg.url)
+    // cfg.cookies = cookieJar.getCookiesSync(cfg.url)
 
     // This where the HTTP request is made.
     // Nano used to use the now-deprecated "request" library but now we're going to

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -375,8 +375,6 @@ module.exports = exports = function dbScope (cfg) {
     // ?drilldown=["author","Dickens"]&drilldown=["publisher","Penguin"]
     req.qsStringifyOptions = { arrayFormat: 'repeat' }
 
-    // cfg.cookies = cookieJar.getCookiesSync(cfg.url)
-
     // This where the HTTP request is made.
     // Nano used to use the now-deprecated "request" library but now we're going to
     // use axios, so let's modify the "req" object to suit axios

--- a/test/nano.request.test.js
+++ b/test/nano.request.test.js
@@ -478,7 +478,7 @@ test('check request doesn\'t mangle bodies containing functions - nano.request',
 test('check request sends user-agent header - nano.request', async () => {
   // mocks
   const response = { ok: true }
-  const scope = nock(COUCH_URL, { reqheaders: { 'user-agent': /^nano/ } })
+  const scope = nock(COUCH_URL, { reqheaders: { 'user-agent': /^@budibase\/nano/ } })
     .get('/db?a=1&b=2')
     .reply(200, response)
 


### PR DESCRIPTION
`cfg.cookies` doesn't appear to be used anywhere, and our profiling is hinting to me that this is a somewhat expensive call. See calls to `getCookies` in blue.

![CleanShot 2024-01-31 at 11 37 10@2x](https://github.com/Budibase/couchdb-nano/assets/338027/fdee69cc-da0e-465a-a0fb-f44d06ba88aa)

Also, upstream also removed this call when they got rid of `tough-cookie` to implement cookie handling in the library itself: https://github.com/apache/couchdb-nano/commit/dc673542ca65998c5e170db95dde3a090bb9a4c9.

